### PR TITLE
Removing bug rarity; this field is only applicable for fish.

### DIFF
--- a/main_app/templates/animals/animal_details.html
+++ b/main_app/templates/animals/animal_details.html
@@ -26,7 +26,6 @@
     <p>Item Number: {{ bug.number }}</p>
     <p>Location Found: {{ bug.location }}</p>
     <p>Weather Found: {{ bug.weather }}</p>
-    <p>Rarity: {{ bug.rarity }}</p>
     <p>Sell Value (Nook's Cranny): {{ bug.sell_nook }} Bells</p>
     <p>Sell Value (Flick): {{ bug.sell_flick }} Bells</p>
     <p>Catchphrases: {{ bug.catchphrases.0 }}</p>


### PR DESCRIPTION
I'm going to go ahead and review this myself since it's a one-line change to a template.  Bug rarity is always blank in the API, and the concept doesn't work the same way for bugs as it does for fish, so the field is inapplicable for bugs.